### PR TITLE
Return and tab keys add tag to tag list

### DIFF
--- a/app/static/js/libs/bootstrap-tagsinput.js
+++ b/app/static/js/libs/bootstrap-tagsinput.js
@@ -364,6 +364,14 @@
 
 
       self.$container.on('keydown', 'input', $.proxy(function(event) {
+        function createTag() {
+          if ($('.typeahead, .twitter-typeahead', self.$container).length === 0) {
+            self.add(self.$input.val());
+            self.$input.val('');
+          }
+          event.preventDefault();
+        }
+
         var $input = $(event.target),
             $inputWrapper = self.findInputWrapper();
 
@@ -411,7 +419,17 @@
               $input.focus();
             }
             break;
-         default:
+            
+          // RETURN
+          case 13:
+            createTag();
+            break;
+
+          // TAB
+          case 9:
+            createTag();
+            break;
+          default:
              // ignore
          }
 


### PR DESCRIPTION
Pressing the return and tab keys should now add a tag to the tag list without any other side effects.

![image](https://cloud.githubusercontent.com/assets/8015872/11494964/44ac9426-97d5-11e5-972b-67de7d431ad1.png)
