### PR TITLE
Note Editing Redirection

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -116,7 +116,7 @@ def edit(id):
 
         db.session.commit()
         flash('The note has been updated.')
-        return redirect(url_for('.index'))
+        return redirect(url_for('.note', id=note.id))
     form.title.data = note.title
     form.body.data = note.body
     form.tags.data = ', '.join(note._get_tags())


### PR DESCRIPTION
When a user edits a note, they are sent back to the same note that they
edited.

fixes https://github.com/levlaz/braindump/issues/73
