### PR TITLE
Fix some bugs in edit note page

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -113,10 +113,11 @@ def edit(id):
         db.session.add(note)
         print form.tags.data
         tags = []
-        for tag in form.tags.data.split(','):
-            tags.append(tag.replace(" ", ""))
-            print form.tags.data
-            print tags
+        if not len(form.tags.data) == 0:
+            for tag in form.tags.data.split(','):
+                tags.append(tag.replace(" ", ""))
+                print form.tags.data
+                print tags
         print tags
         note.str_tags = (tags)
 

--- a/app/static/js/braindump_editor.js
+++ b/app/static/js/braindump_editor.js
@@ -10,6 +10,7 @@ editor.setOption("maxLines", 25);
 var textarea = $('textarea[id="body"]').hide();
 var textarea_html_label = $('label[for="body_html"]').hide();
 var textarea_html = $('textarea[id="body_html"]').hide();
+textarea_html.val(marked(textarea.val()));
 editor.getSession().setValue(textarea.val());
 editor.getSession().on('change', function(){
   textarea_html.val(marked(editor.getSession().getValue()));


### PR DESCRIPTION
1. Prevent saving empty tag into database in edit note page
2. Cannot render markdown after we edit and submit note without changing contents
