### PR TITLE
github auth: login_user on first registration

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -208,7 +208,7 @@ def authorized(auth):
         elif user is not None:
             user.confirmed=True
             db.session.commit()
-            login_user(user)
+        login_user(user)
         return redirect(request.args.get('next') or url_for('main.index'))
 
 


### PR DESCRIPTION
Previously it registered the user the first time they logged in
with github, but didn't actually log them in until the second time.

I think there may also be an issue with GitHub application for the
application deployed at braindump.pw. It's saying "redirect uri 
mismatch" with `http://braindump.pw/auth/login/authorized/github`,
so I'm guessing a different URL is specified in the application settings
